### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release build
 run-name: Release ${{ github.event.inputs.tag_name }}
+permissions:
+  contents: write
+  actions: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/treeentertainment/somecamera/security/code-scanning/2](https://github.com/treeentertainment/somecamera/security/code-scanning/2)

To fix the problem, you should explicitly declare a `permissions` block at either the workflow root or at the job level, specifying only the required permissions for the actions in use. On inspection, only the `Create GitHub Release` step needs `contents: write`, while the `dawidd6/action-download-artifact` step requires at most `actions: read` (to access workflow artifacts). The other steps (shell commands) do not need any additional permission. Add the following under the workflow root (recommended to cover all jobs): 

Add, after the workflow name and run-name:
```
permissions:
  contents: write
  actions: read
```

This will restrict the GITHUB_TOKEN to only what's necessary for the artifact download and release creation.

Implement this by modifying `.github/workflows/release.yml` to insert the `permissions:` block directly after line 2.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
