### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build APK
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/treeentertainment/somecamera/security/code-scanning/1](https://github.com/treeentertainment/somecamera/security/code-scanning/1)

**How to fix:**  
Add a `permissions` block explicitly to the workflow to limit the `GITHUB_TOKEN` and job permissions to the minimum required. The minimal `contents: read` permission suffices for this workflow, since the actions do not push code, create releases, or interact with pull requests/issues. This `permissions` block should be placed at the root level in the workflow YAML (line 2), so it applies to all jobs.

**Detailed fix:**  
Insert a `permissions:` block after the workflow `name:` (after line 1), with `contents: read`. No changes to steps or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
